### PR TITLE
check the invest version in order to properly assign filename variables

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -29,6 +29,15 @@ function buildJSON(investTag) {
   let validTag = investTag.match(regex);
   if (validTag !== null){latestTag = investTag;}
   else {latestTag = defaultTag;}
+  let arch = 'x64';
+  let macExt = 'dmg';
+  if (
+    Number(latestTag.split('.')[0]) == 3
+    && Number(latestTag.split('.')[1]) < 9
+  ) {
+    arch = 'x86'
+    macExt = 'zip'
+  }
 
   const baseUrl = "https://storage.googleapis.com/releases.naturalcapitalproject.org";
   responseJson = {
@@ -37,11 +46,11 @@ function buildJSON(investTag) {
     "links": [
       {
         "title": `Download InVEST ${latestTag} (Windows)`,
-        "url": `${baseUrl}/invest/${latestTag}/InVEST_${latestTag}_x64_Setup.exe`
+        "url": `${baseUrl}/invest/${latestTag}/InVEST_${latestTag}_${arch}_Setup.exe`
       },
       {
         "title": `Download InVEST ${latestTag} (Mac)`,
-        "url": `${baseUrl}/invest/${latestTag}/InVEST-${latestTag}-mac.zip`
+        "url": `${baseUrl}/invest/${latestTag}/InVEST-${latestTag}-mac.${macExt}`
       },
       {
         "title": "InVEST User's Guide (online)",
@@ -53,7 +62,7 @@ function buildJSON(investTag) {
       },
       {
         "title": "Individual Sample Datasets for InVEST",
-        "url": `http://releases.naturalcapitalproject.org/?prefix=invest/${latestTag}data/`
+        "url": `http://releases.naturalcapitalproject.org/?prefix=invest/${latestTag}/data/`
       },
       {
         "title": "生态系统服务评估与权衡（InVEST）模型（3.2.0 版本）使用手册",


### PR DESCRIPTION
Moving from invest 3.8.9 to 3.9.0 - Windows builds are now `x64` and Mac builds are now `.dmg`. These are components of the artifact filenames, so this PR has some logic to work with before and after this version transition.