### PR TITLE
New links for the Workbench

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -45,7 +45,6 @@ function buildJSON(investTag) {
     "nid":"14056",
     "links": [
       {
-<<<<<<< HEAD
         "title": `Download InVEST ${latestTag} (Windows) - new Workbench!`,
         "url": `${baseUrl}/invest/${latestTag}/workbench/InVEST_${latestTag}_workbench_win32_x64.exe`
       },
@@ -59,15 +58,7 @@ function buildJSON(investTag) {
       },
       {
         "title": `Download InVEST ${latestTag} (Mac) - old application`,
-        "url": `${baseUrl}/invest/${latestTag}/InVEST-${latestTag}-mac.zip`
-=======
-        "title": `Download InVEST ${latestTag} (Windows)`,
-        "url": `${baseUrl}/invest/${latestTag}/InVEST_${latestTag}_${arch}_Setup.exe`
-      },
-      {
-        "title": `Download InVEST ${latestTag} (Mac)`,
         "url": `${baseUrl}/invest/${latestTag}/InVEST_${latestTag}.${macExt}`
->>>>>>> 12e3fd4acf4226acef8b516856b6b90a03442233
       },
       {
         "title": "InVEST User's Guide (online)",

--- a/app/index.js
+++ b/app/index.js
@@ -36,11 +36,19 @@ function buildJSON(investTag) {
     "nid":"14056",
     "links": [
       {
-        "title": `Download InVEST ${latestTag} (Windows)`,
+        "title": `Download InVEST ${latestTag} (Windows) - new Workbench!`,
+        "url": `${baseUrl}/invest/${latestTag}/workbench/InVEST_${latestTag}_workbench_win32_x64.exe`
+      },
+      {
+        "title": `Download InVEST ${latestTag} (Mac) - new Workbench!`,
+        "url": `${baseUrl}/invest/${latestTag}/workbench/InVEST-${latestTag}_workbench_darwin_x64.dmg`
+      },
+      {
+        "title": `Download InVEST ${latestTag} (Windows) - old application`,
         "url": `${baseUrl}/invest/${latestTag}/InVEST_${latestTag}_x64_Setup.exe`
       },
       {
-        "title": `Download InVEST ${latestTag} (Mac)`,
+        "title": `Download InVEST ${latestTag} (Mac) - old application`,
         "url": `${baseUrl}/invest/${latestTag}/InVEST-${latestTag}-mac.zip`
       },
       {


### PR DESCRIPTION
Here's my suggestion for how the new download links should read. Trying to give prominence to the Workbench, while also conveying that the old UI is still available (with the same version of invest models), and doing it all in about two words. I'm very open to suggestions for improvement on the language though.

And when is the best time to merge this? Probably after the release is otherwise complete?